### PR TITLE
Do not render TOC if it is empty.

### DIFF
--- a/classes/Toc.php
+++ b/classes/Toc.php
@@ -246,48 +246,55 @@ class Toc
     $replacements = [];
     // Find all occurrences of TOC and MINITOC in content
     $regex = '~(<p>)?\s*\[(?P<type>(?:MINI)?TOC)\]\s*(?(1)</p>)~i';
-    if (preg_match_all($regex, $content, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER)) {
-      // Generate TOC
-       $toc = $this->createToc($content);
-      foreach ($matches as $match) {
-        $offset = $match[0][1];
-        $type = strtolower($match['type'][0]);
+    if (preg_match_all($regex, $content, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) === false) {
+      return $content;
+    }
 
-        // Initialize variables
-        $current = -1;
-        $minitoc = [];
+    // Generate TOC
+    $toc = $this->createToc($content);
 
-        if ($type == 'toc') {
-          $minitoc = $toc;
-        } else {
-          // Get current (sub-)heading
-          foreach ($toc as $index => $heading) {
-            if ($index < $offset) {
-              $current = $index;
+    if (empty($toc)) {
+      return preg_replace($regex, null, $content);
+    }
+
+    foreach ($matches as $match) {
+      $offset = $match[0][1];
+      $type = strtolower($match['type'][0]);
+
+      // Initialize variables
+      $current = -1;
+      $minitoc = [];
+
+      if ($type == 'toc') {
+        $minitoc = $toc;
+      } else {
+        // Get current (sub-)heading
+        foreach ($toc as $index => $heading) {
+          if ($index < $offset) {
+            $current = $index;
+          } else {
+            $level = $toc[$current]['level'];
+            if ($heading['level'] > $level) {
+              $minitoc[$index] = $heading;
             } else {
-              $level = $toc[$current]['level'];
-              if ($heading['level'] > $level) {
-                $minitoc[$index] = $heading;
-              } else {
-                break;
-              }
+              break;
             }
           }
         }
-
-        // Render TOC
-        $vars['toc'] = [
-          'list' => $minitoc,
-          'type' => $type,
-          'heading' => ($current > -1) ? $toc[$current] : null,
-        ] + $options->toArray();
-
-        $template = 'partials/toc' . TEMPLATE_EXT;
-        $minitoc = $twig->processTemplate($template, $vars);
-
-        // Save rendered TOC for later replacement
-        $replacements[] = $minitoc;
       }
+
+      // Render TOC
+      $vars['toc'] = [
+        'list' => $minitoc,
+        'type' => $type,
+        'heading' => ($current > -1) ? $toc[$current] : null,
+      ] + $options->toArray();
+
+      $template = 'partials/toc' . TEMPLATE_EXT;
+      $minitoc = $twig->processTemplate($template, $vars);
+
+      // Save rendered TOC for later replacement
+      $replacements[] = $minitoc;
     }
 
     // Tocify content


### PR DESCRIPTION
I removed an indent level by returning the $content directly if preg_match_all found nothing. This prevents through the trouble of calling `tocify` for nothing.

Furthermore, I built up on your answer to #6, it was still necessary for me to strip all [TOC]/[MINITOC], which is done by a simple preg_replace.
