### PR TITLE
Add "headeranchor" class to headings

### DIFF
--- a/classes/Toc.php
+++ b/classes/Toc.php
@@ -207,9 +207,9 @@ class Toc
             $id, strip_tags($text), $text, rtrim($extra), $icon);
         }
 
-        // Add id attribute if permalinks or anchorlinks are used
+        // Add id attribute (and a "headeranchor" class) if permalinks or anchorlinks are used
         $link = $options->get('anchorlink', $options->get('permalink'));
-        $attributes += $link ? ['id' => $id] : [];
+        $attributes += $link ? ['id' => $id, 'class' => 'headeranchor'] : [];
 
         // Prevent TOC and MINITOC insertion in headings
         $text = str_ireplace(['[TOC]', '[MINITOC]'],

--- a/classes/Toc.php
+++ b/classes/Toc.php
@@ -173,6 +173,8 @@ class Toc
         $attributes = $this->parseAttributes($match['attr']);
         $id = isset($attributes['id']) ? $attributes['id'] : $this->hyphenize($text);
 
+        $classes = isset($attributes['class']) ? $attributes['class'] . ' headeranchor' : 'headeranchor';
+        
         // Replace empty id with hash of text
         if (strlen($id) == 0) {
           $id = substr(md5($text), 0, 6);
@@ -209,7 +211,10 @@ class Toc
 
         // Add id attribute (and a "headeranchor" class) if permalinks or anchorlinks are used
         $link = $options->get('anchorlink', $options->get('permalink'));
-        $attributes += $link ? ['id' => $id, 'class' => 'headeranchor'] : [];
+        $attributes += $link ? ['id' => $id] : [];
+        if ($link) {
+          $attributes['class'] = $classes;
+        }
 
         // Prevent TOC and MINITOC insertion in headings
         $text = str_ireplace(['[TOC]', '[MINITOC]'],

--- a/classes/Toc.php
+++ b/classes/Toc.php
@@ -205,7 +205,7 @@ class Toc
           // Load header anchor link icon
           $icon = $options->get('icon', '#');
 
-          $text = sprintf('<a class="headeranchor-link%4$s" aria-hidden="true" href="#%s" name="%1$s" title="Permanent link: %2$s" data-icon="%5$s">%3$s</a>',
+          $text = sprintf('<a class="headeranchor-link%4$s" aria-hidden="true" href="#%$1s" title="Permanent link: %2$s" data-icon="%5$s">%3$s</a>',
             $id, strip_tags($text), $text, rtrim($extra), $icon);
         }
 

--- a/classes/Toc.php
+++ b/classes/Toc.php
@@ -205,7 +205,7 @@ class Toc
           // Load header anchor link icon
           $icon = $options->get('icon', '#');
 
-          $text = sprintf('<a class="headeranchor-link%4$s" aria-hidden="true" href="#%$1s" title="Permanent link: %2$s" data-icon="%5$s">%3$s</a>',
+          $text = sprintf('<a class="headeranchor-link%4$s" aria-hidden="true" href="#%1$s" title="Permanent link: %2$s" data-icon="%5$s">%3$s</a>',
             $id, strip_tags($text), $text, rtrim($extra), $icon);
         }
 


### PR DESCRIPTION
I like to add (CSS) classes to elements to style them. Here, I wanted to target "tocified" headings (for example with `:target`, when we have clicked in the TOC and went to the heading).

The code is not as concise as the original, because I couldn't use "+=" (it does not overwrite the first array argument).

Pre-existing classes added in Markdown are of course preserved.