### PR TITLE
Fix nesting of TOC list.

### DIFF
--- a/assets/css/toc.css
+++ b/assets/css/toc.css
@@ -23,15 +23,15 @@
   font-weight: bold;
   margin-bottom: .5em;
 }
-.table-of-contents ul {
+.table-of-contents ol {
   list-style: none;
   padding: 0;
   margin: 0;
 }
-.table-of-contents > ul {
+.table-of-contents > ol {
   margin-left: 1.5em;
 }
-.table-of-contents ul ul {
+.table-of-contents ol ol {
   padding: 0 1em;
 }
 .table-of-contents li {

--- a/languages.yaml
+++ b/languages.yaml
@@ -114,6 +114,8 @@ en:
         '~([A-Z]+)([A-Z][a-z])~': '\1-\2'
         '~([a-z]{2,})([A-Z])~': '\1-\2'
 
+      TOC_TITLE: "Table of contents"
+      MINITOC_TITLE: "Overview:"
 # French
 fr:
   PLUGINS:
@@ -162,3 +164,6 @@ fr:
         # Character replacements
         '~([A-Z]+)([A-Z][a-z])~': '\1-\2'
         '~([a-z]{2,})([A-Z])~': '\1-\2'
+
+      TOC_TITLE: "Table des matières"
+      MINITOC_TITLE: "Vue d'ensemble"

--- a/templates/plugins/toc/toc.html.twig
+++ b/templates/plugins/toc/toc.html.twig
@@ -17,7 +17,7 @@
     {% endif %}
   {% endfor %}
 
-  <ul>
+  <ol>
   {# Generate links #}
   {% set level = base_indent %}
   {% for entry in toc.list if (toc.baselevel <= entry.level) and (entry.level <= toc.headinglevel) %}
@@ -25,32 +25,34 @@
     {# Create list markup for headings #}
     {% if entry.indent > level %}
       {% for i in 1..(entry.indent - level) %}
-        <li><ul>
+      <ol>
       {% endfor %}
     {% elseif entry.indent < level %}
       {% for i in 1..(level - entry.indent) %}
-        </ul></li>
+      </ol>
       {% endfor %}
     {% endif %}
 
-    {# Set current level to heading level #}
-    {% set level = entry.indent %}
-
     {# Show TOC link based on anchorlinks option #}
     {% if toc.anchorlink %}
-      <li><a href="#{{ entry.id|e('html_attr') }}" class="toclink" title="{{ entry.text|striptags }}">{{ entry.text }}</a></li>
+      {% if not loop.first and entry.indent == level %}</li>{% endif %}
+      <li><a href="#{{ entry.id }}" class="toclink" title="{{ entry.text }}">{{ entry.text }}</a>
     {% else %}
-      <li><span class="toclink">{{ entry.text|truncate(32, " ") }}</span></li>
+      {% if not loop.first and entry.indent == level %}</li>{% endif %}
+      <li><span class="toclink">{{ entry.text|truncate(32, " ") }}</span>
     {% endif %}
+    {# Set current level to heading level #}
+    {% set level = entry.indent %}
   {% endfor %}
 
   {# Add missing closing tags #}
   {% if (level - base_indent) > 0 %}
     {% for i in 1..(level - base_indent) %}
-      </ul></li>
+  </ol></li>
     {% endfor %}
   {% endif %}
 
-  </ul>
+</li>
+</ol>
 </nav>
 

--- a/templates/plugins/toc/toc.html.twig
+++ b/templates/plugins/toc/toc.html.twig
@@ -3,9 +3,9 @@
   {% if toc.title %}
     {# Format header according to TOC type #}
     {% if toc.type == "toc" %}
-      <span class="toctitle">Table of contents:</span>
+      <span class="toctitle"> {{ 'PLUGINS.TOC.TOC_TITLE' | t }}</span>
     {% elseif toc.type == "minitoc" %}
-      <span class="toctitle">Overview:</span>
+      <span class="toctitle">{{ 'PLUGINS.TOC.MINITOC_TITLE' | t }}</span>
     {% endif %}
   {% endif %}
 

--- a/templates/plugins/toc/toc.html.twig
+++ b/templates/plugins/toc/toc.html.twig
@@ -1,5 +1,5 @@
 {# Render table of contents block #}
-<nav class="table-of-contents {{ toc.type }}" role="navigation">
+<nav class="table-of-contents {{ toc.type }}">
   {% if toc.title %}
     {# Format header according to TOC type #}
     {% if toc.type == "toc" %}


### PR DESCRIPTION
As seen in #17, the list nesting is not semantically correct.

I changed `<ul>` to `<ol>` too, because it seemed more logical to have an ordered list - but maybe it isn't necessary, on the Net I found examples of both for tables of contents.

And I added translatable titles for TOC & MINITOC (in english and french only, sorry…).