### PR TITLE
fix syntax for PHP 7.4+

### DIFF
--- a/classes/Toc.php
+++ b/classes/Toc.php
@@ -65,7 +65,7 @@ class Toc
                 }
 
                 // Ignore headings in code, pre or blockquote environments
-                if (!$text || $tag{0} !== 'h') {
+                if (!$text || $tag[0] !== 'h') {
                     continue;
                 }
 
@@ -126,7 +126,7 @@ class Toc
                 $text = trim($match['text']);
 
                 // Don't consider headings in code or pre environments
-                if (($tag{0} !== 'h') || (mb_strlen($text) == 0)) {
+                if (($tag[0] !== 'h') || (mb_strlen($text) == 0)) {
                     // Ignore empty headers, too
                     return $match[0];
                 }

--- a/vendor/neitanod/forceutf8/src/ForceUTF8/Encoding.php
+++ b/vendor/neitanod/forceutf8/src/ForceUTF8/Encoding.php
@@ -193,11 +193,11 @@ class Encoding {
   
     $buf = "";
     for($i = 0; $i < $max; $i++){
-        $c1 = $text{$i};
+        $c1 = $text[$i];
         if($c1>="\xc0"){ //Should be converted to UTF8, if it's not UTF8 already
-          $c2 = $i+1 >= $max? "\x00" : $text{$i+1};
-          $c3 = $i+2 >= $max? "\x00" : $text{$i+2};
-          $c4 = $i+3 >= $max? "\x00" : $text{$i+3};
+          $c2 = $i+1 >= $max? "\x00" : $text[$i+1];
+          $c3 = $i+2 >= $max? "\x00" : $text[$i+2];
+          $c4 = $i+3 >= $max? "\x00" : $text[$i+3];
             if($c1 >= "\xc0" & $c1 <= "\xdf"){ //looks like 2 bytes UTF8
                 if($c2 >= "\x80" && $c2 <= "\xbf"){ //yeah, almost sure it's UTF8 already
                     $buf .= $c1 . $c2;


### PR DESCRIPTION
Since PHP 7.4, the curly braces are not allowed anymore, as seen in #27 
Source : https://wiki.php.net/rfc/deprecate_curly_braces_array_access 

Tested on GravCMS 1.7 on PHP 8